### PR TITLE
商品削除機能

### DIFF
--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -29,3 +29,4 @@ RSpec.describe ItemsController, type: :controller do
     end
   end
 end
+


### PR DESCRIPTION
# What
商品を削除する機能を実装。商品登録後、登録ユーザーとして商品詳細ページに行った際に
商品の削除が出来る。

# Why
間違った商品登録した際に、消去する機能が無いと取り消しが出来ないため。